### PR TITLE
Updates open_airborne_obs to be consistent

### DIFF
--- a/spectral_util/mosaic.py
+++ b/spectral_util/mosaic.py
@@ -329,9 +329,9 @@ def build_obs_nc(output_file, input_file_list, ignore_file_list, x_resolution, y
             logging.debug(f'{file} Ignored')
             continue
 
-        local_meta, obs, loc = spec_io.load_data(file.strip(), lazy=True, load_glt=False, load_loc=True)
-        loc = np.stack(proj(loc[...,0],loc[...,1]),axis=-1)
-            
+        local_meta, obs = spec_io.load_data(file.strip(), lazy=True, load_glt=False, load_loc=True)
+        loc = np.stack(proj(local_meta.loc[...,0],local_meta.loc[...,1]),axis=-1)
+
         sub_glt, sub_glt_insert_idx = find_subgrid_locations(y_grid, x_grid, loc[...,1], loc[...,0], n_workers=n_cores)  
 
         if sub_glt is None:

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -110,11 +110,11 @@ def load_data(input_file, lazy=True, load_glt=False, load_loc=False):
             - numpy.ndarray or netCDF4.Variable: The data, either as a lazy-loaded variable or a fully loaded numpy array.
     """
     if input_file.endswith(('.hdr', '.dat', '.img')) or '.' not in os.path.basename(input_file):
-        return open_envi(input_file, lazy=True)
+        return open_envi(input_file, lazy=lazy)
     elif input_file.endswith('.nc'):
-        return open_netcdf(input_file, lazy=True, load_glt=load_glt, load_loc=load_loc)
+        return open_netcdf(input_file, lazy=lazy, load_glt=load_glt, load_loc=load_loc)
     elif input_file.endswith('.tif'):
-        return open_tif(input_file, lazy=True)
+        return open_tif(input_file, lazy=lazy)
     else:
         raise ValueError(f'Unknown file type for {input_file}')
 
@@ -254,7 +254,8 @@ def open_tif(input_file, lazy=False):
             - GenericGeoMetadata: An object containing the wavelengths and FWHM.
             - numpy.ndarray: The data, either as a lazy-loaded memory map or a fully loaded numpy array.
     """
-    logging.warning('Lazy loading not supported for GeoTIFF data.')
+    if lazy:
+        logging.warning('Lazy loading not supported for GeoTIFF data.')
     ds = gdal.Open(input_file)
     proj = ds.GetProjection()
     trans = ds.GetGeoTransform()

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -16,7 +16,7 @@ numpy_to_gdal = {
 }
 
 class GenericGeoMetadata:
-    def __init__(self, band_names, geotransform=None, projection=None, glt=None, pre_orthod=False, nodata_value=None):
+    def __init__(self, band_names, geotransform=None, projection=None, glt=None, pre_orthod=False, nodata_value=None, loc=None):
         """
         Initializes the GenericGeoMetadata object.
 
@@ -34,6 +34,7 @@ class GenericGeoMetadata:
         self.glt = glt
         self.pre_orthod = False
         self.nodata_value = nodata_value
+        self.loc = loc
 
         if pre_orthod:
             self.orthoable = False
@@ -292,8 +293,6 @@ def open_netcdf(input_file, lazy=True, load_glt=False, load_loc=False):
         return open_airborne_obs(input_file, lazy=lazy, load_glt=load_glt, load_loc=load_loc)
     elif 'ang' in input_file.lower()  and 'rfl' in input_file.lower():
         return open_airborne_rfl(input_file, lazy=lazy)
-    elif 'AV3' in input_file and 'OBS' in input_file:
-        return open_airborne_obs(input_file, lazy=lazy, load_glt=load_glt)
     else:
         raise ValueError(f'Unknown file type for {input_file}')
 
@@ -419,8 +418,10 @@ def open_airborne_obs(input_file, lazy=True, load_glt=False, load_loc=False):
     obs_names = list(ds['observation_parameters'].variables.keys())
 
     nodata_value = float(ds['observation_parameters'][obs_names[0]]._FillValue)
+    glt = None
     if load_glt:
         glt = np.stack([ds['geolocation_lookup_table']['sample'][:],ds['geolocation_lookup_table']['line'][:]],axis=-1)
+    loc = None
     if load_loc:
         loc = np.stack([ds['lon'][:],ds['lat'][:]],axis=-1)
 
@@ -429,16 +430,9 @@ def open_airborne_obs(input_file, lazy=True, load_glt=False, load_loc=False):
         logging.warning("Lazy loading not supported for observation data.")
     obs = np.stack([ds['observation_parameters'][on] for on in obs_names], axis=-1)
     
-    meta = GenericGeoMetadata(obs_names, trans, proj, glt=None, pre_orthod=True, nodata_value=nodata_value)
+    meta = GenericGeoMetadata(obs_names, trans, proj, glt=glt, pre_orthod=True, nodata_value=nodata_value, loc=loc)
 
-    if load_glt and load_loc:
-        return meta, obs, glt, loc
-    elif load_glt:
-        return meta, obs, glt
-    elif load_loc:
-        return meta, obs, loc
-    else:
-        return meta, obs
+    return meta, obs
 
 
 def get_extent_from_obs(input_file, get_resolution=False):


### PR DESCRIPTION
@pgbrodrick: this PR updates the load_data behavior in spec_io.py to be consistent when reading airborne OBS files.

spec_io.load_data() will call open_airborne_obs when provided a netCDF4 AV3 OBS file. Currently, this does not add the glt or the loc to the GenericGeoMetadata class regardless of the load_glt or load_loc flags. When set, these flags just change the return values for the function to include these things. This makes the interface inconsistent to load_data, as the other functions return an instance of a metadata and then the data.

This PR changes the behavior of open_airborne_obs to add the glt and loc to the GenericGeoMetadata class, depending on the flags, and then return that and the obs data itself. This required adding the loc field to the metadata class too.

I also removed a redundant line from the if/else structure that dispatches the input file to the correct read function.