### PR TITLE
Fix ortho_data in spec_io.py

### DIFF
--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -135,10 +135,12 @@ def ortho_data(data, glt, glt_mask=None, glt_nodata=0, nodata_value=-9999):
     valid_glt = np.all(glt != glt_nodata, axis=-1)
     if glt_mask is not None:
         valid_glt = np.logical_and(valid_glt, glt_mask)
+    
+    glt_tmp = np.abs(glt).astype(int)
 
     if glt_nodata == 0:
-        glt[valid_glt] -= 1
-    outdata[valid_glt, :] = data[np.abs(glt[valid_glt, 1]), np.abs(glt[valid_glt, 0]), :]
+        glt_tmp[valid_glt] -= 1
+    outdata[valid_glt, :] = data[np.abs(glt_tmp[valid_glt, 1]), np.abs(glt_tmp[valid_glt, 0]), :]
     return outdata
 
 

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -131,8 +131,11 @@ def ortho_data(data, glt, glt_mask=None, glt_nodata=0, nodata_value=-9999):
     Returns:
         numpy.ndarray: The orthorectified data.
     """
+    do_squeeze = False
     if len(data.shape) == 2:
         data = np.expand_dims(data, axis = -1)
+        do_squeeze = True
+
     outdata = np.zeros((glt.shape[0], glt.shape[1], data.shape[2]), dtype=data.dtype) + nodata_value
     valid_glt = np.all(glt != glt_nodata, axis=-1)
     if glt_mask is not None:
@@ -143,7 +146,10 @@ def ortho_data(data, glt, glt_mask=None, glt_nodata=0, nodata_value=-9999):
     if glt_nodata == 0:
         glt_tmp[valid_glt] -= 1
     outdata[valid_glt, :] = data[np.abs(glt_tmp[valid_glt, 1]), np.abs(glt_tmp[valid_glt, 0]), :]
-    data = np.squeeze(data) # Change it back!
+
+    if do_squeeze:
+        data = np.squeeze(data) # Change it back!
+
     return outdata
 
 

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -131,6 +131,8 @@ def ortho_data(data, glt, glt_mask=None, glt_nodata=0, nodata_value=-9999):
     Returns:
         numpy.ndarray: The orthorectified data.
     """
+    if len(data.shape) == 2:
+        data = np.expand_dims(data, axis = -1)
     outdata = np.zeros((glt.shape[0], glt.shape[1], data.shape[2]), dtype=data.dtype) + nodata_value
     valid_glt = np.all(glt != glt_nodata, axis=-1)
     if glt_mask is not None:
@@ -141,8 +143,8 @@ def ortho_data(data, glt, glt_mask=None, glt_nodata=0, nodata_value=-9999):
     if glt_nodata == 0:
         glt_tmp[valid_glt] -= 1
     outdata[valid_glt, :] = data[np.abs(glt_tmp[valid_glt, 1]), np.abs(glt_tmp[valid_glt, 0]), :]
+    data = np.squeeze(data) # Change it back!
     return outdata
-
 
 
 def write_cog(output_file, data, meta, ortho=True, nodata_value=-9999):

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -149,6 +149,7 @@ def ortho_data(data, glt, glt_mask=None, glt_nodata=0, nodata_value=-9999):
 
     if do_squeeze:
         data = np.squeeze(data) # Change it back!
+        outdata = np.squeeze(outdata)
 
     return outdata
 


### PR DESCRIPTION
@pgbrodrick: This PR fixes the ortho_data function in spec_io.py when using the glt produced from open_airborne_obs.

This fixes three problems I had with ortho_data:
1) The glt from open_airborne_obs is an array of floats, but it should be ints
2) The glt from open_airborne_obs has negatives, so it needs an np.abs()
3) Repeated calls of ortho_data would incorrectly continue to decrement the glt, so this uses a local copy

Combined with my other PR ([https://github.com/emit-sds/SpectralUtil/pull/9](https://github.com/emit-sds/SpectralUtil/pull/9)), this enables the following usage:

```
m, d = spec_io.load_data('/store/jfahlen/coincident_overpasses/av3_October_2024/granules/AV320241004t163242_014_L2B_GHG_1/AV320241004t163242_014_L1B_ORT_55901fd4_OBS.nc', load_glt = True)
do = spec_io.ortho_data(d, m.glt)
```
