### PR TITLE
Add helper routines to find, download, and combine into VRTs AV3 lines using earthaccess

### DIFF
--- a/spectral_util/earthaccess_helpers.py
+++ b/spectral_util/earthaccess_helpers.py
@@ -109,7 +109,7 @@ def join_AV3_scenes_as_VRT_pixel_time_only(fid, storage_location, output_locatio
         driver = gdal.GetDriverByName('GTiff')
         outDataset = driver.Create(out_tif, d_obs_ort.shape[1], d_obs_ort.shape[0], 1,
                                    gdal.GDT_Float32, options = ['PROFILE=GeoTIFF'])
-        outDataset.GetRasterBand(1).WriteArray(d_obs_ort[:,:,0])
+        outDataset.GetRasterBand(1).WriteArray(d_obs_ort[:,:])
         outDataset.GetRasterBand(1).SetNoDataValue(-9999)
         outDataset.SetProjection(m_obs.projection)
         outDataset.SetGeoTransform(m_obs.geotransform)
@@ -151,7 +151,7 @@ def join_AV3_scenes_as_VRT(fid, granule_storage_location, output_location,
     for tag in tags_to_join:
         files = []
         for folder in folders:
-            fs = json.load(open(os.path.join(folder, 'data_files.json','r')))[f'{tag}']
+            fs = json.load(open(os.path.join(folder, 'data_files.json'),'r'))[f'{tag}']
             files.append(fs)
 
         scene_numbers = [os.path.split(x)[-1].split('_')[1] for x in files]

--- a/spectral_util/earthaccess_helpers.py
+++ b/spectral_util/earthaccess_helpers.py
@@ -18,14 +18,14 @@ import spec_io
 @click.option('--search_only', is_flag=True, default=False, help='Location to put symlinks')
 def find_download_and_combine(output_folder, 
                               temporal = None, 
-                              count = 200000,
+                              count = 2000,
                               bounding_box = None,
                               overwrite = False,
                               symlinks_folder = None,
                               search_only = False):
     '''Find, download, and combine into VRTs all matching granules and store in OUTPUT_FOLDER
 
-    Rceommended usage: start with --seach_only to review FIDs before downloading
+    Rceommended usage: start with --search_only to review FIDs before downloading
     
     Search a DAAC using Earthaccess to find granules matching temporal and bounding_box. Download all the L1B and L2B products for
     each granule (except the full radiance as it takes too long and we don't need it generally for GHG analysis). Then, for each line,

--- a/spectral_util/earthaccess_helpers.py
+++ b/spectral_util/earthaccess_helpers.py
@@ -106,15 +106,16 @@ def join_AV3_scenes_as_VRT_pixel_time_only(fid, storage_location, output_locatio
         d_obs_ort = spec_io.ortho_data(d_obs[:,:,0], m_obs.glt)
 
         # Save the orthoed times to tif so we can make a vrt below
-        driver = gdal.GetDriverByName('GTiff')
-        outDataset = driver.Create(out_tif, d_obs_ort.shape[1], d_obs_ort.shape[0], 1,
-                                   gdal.GDT_Float32, options = ['PROFILE=GeoTIFF'])
-        outDataset.GetRasterBand(1).WriteArray(d_obs_ort[:,:])
-        outDataset.GetRasterBand(1).SetNoDataValue(-9999)
-        outDataset.SetProjection(m_obs.projection)
-        outDataset.SetGeoTransform(m_obs.geotransform)
-        outDataset.FlushCache() # saves to disk!!
-        outDataset = None
+        write_geotiff(d_obs_ort, m_obs, out_tif)
+        #driver = gdal.GetDriverByName('GTiff')
+        #outDataset = driver.Create(out_tif, d_obs_ort.shape[1], d_obs_ort.shape[0], 1,
+        #                           gdal.GDT_Float32, options = ['PROFILE=GeoTIFF'])
+        #outDataset.GetRasterBand(1).WriteArray(d_obs_ort[:,:])
+        #outDataset.GetRasterBand(1).SetNoDataValue(-9999)
+        #outDataset.SetProjection(m_obs.projection)
+        #outDataset.SetGeoTransform(m_obs.geotransform)
+        #outDataset.FlushCache() # saves to disk!!
+        #outDataset = None
 
         j['OBS_ORT_times_only'] = out_tif
         json.dump(j, open(os.path.join(folder, 'data_files.json'),'w'), indent = 4)
@@ -182,24 +183,25 @@ def join_AV3_scenes_as_VRT(fid, granule_storage_location, output_location,
 
             # Make orthoed tif
             rdn_ort_tif_filename = '.'.join(rdn_filename.strip().split('.')[:-1]) + '_ORT.tif'
-            driver = gdal.GetDriverByName('GTiff')
-            outDataset = driver.Create(rdn_ort_tif_filename, 
-                                       rgb_data.shape[1], rgb_data.shape[0], rgb_data.shape[2],
-                                       gdal.GDT_Float32, options = ['COMPRESS=LZW'])
-            # This commented out part doesn't work, you have to put the numbers in by hand!
-            #for i in np.arange(rgb_data.shape[-1]):
-            #    outDataset.GetRasterBand(i+1).WriteArray(rgb_data[:,:,i])
-            #    outDataset.GetRasterBand(i+1).SetNoDataValue(-9999)
-            outDataset.GetRasterBand(1).WriteArray(rgb_data[:,:,0])
-            outDataset.GetRasterBand(1).SetNoDataValue(-9999)
-            outDataset.GetRasterBand(2).WriteArray(rgb_data[:,:,1])
-            outDataset.GetRasterBand(2).SetNoDataValue(-9999)
-            outDataset.GetRasterBand(3).WriteArray(rgb_data[:,:,2])
-            outDataset.GetRasterBand(3).SetNoDataValue(-9999)
-            outDataset.SetProjection(m_obs.projection)
-            outDataset.SetGeoTransform(m_obs.geotransform)
-            outDataset.FlushCache() ##saves to disk!!
-            outDataset = None
+            write_geotiff(rgb_data, m_obs, rdn_ort_tif_filename)
+            #driver = gdal.GetDriverByName('GTiff')
+            #outDataset = driver.Create(rdn_ort_tif_filename, 
+            #                           rgb_data.shape[1], rgb_data.shape[0], rgb_data.shape[2],
+            #                           gdal.GDT_Float32, options = ['COMPRESS=LZW'])
+            ## This commented out part doesn't work, you have to put the numbers in by hand!
+            ##for i in np.arange(rgb_data.shape[-1]):
+            ##    outDataset.GetRasterBand(i+1).WriteArray(rgb_data[:,:,i])
+            ##    outDataset.GetRasterBand(i+1).SetNoDataValue(-9999)
+            #outDataset.GetRasterBand(1).WriteArray(rgb_data[:,:,0])
+            #outDataset.GetRasterBand(1).SetNoDataValue(-9999)
+            #outDataset.GetRasterBand(2).WriteArray(rgb_data[:,:,1])
+            #outDataset.GetRasterBand(2).SetNoDataValue(-9999)
+            #outDataset.GetRasterBand(3).WriteArray(rgb_data[:,:,2])
+            #outDataset.GetRasterBand(3).SetNoDataValue(-9999)
+            #outDataset.SetProjection(m_obs.projection)
+            #outDataset.SetGeoTransform(m_obs.geotransform)
+            #outDataset.FlushCache() ##saves to disk!!
+            #outDataset = None
 
             j['RDN_QL_ORT'] = rdn_ort_tif_filename
             json.dump(j, open(os.path.join(folder, 'data_files.json'),'w'), indent = 4)
@@ -211,6 +213,33 @@ def join_AV3_scenes_as_VRT(fid, granule_storage_location, output_location,
         my_vrt = None
     
     return fid_with_scene_numbers
+
+def write_geotiff(data, meta, output_filename):
+    # This commented out part doesn't work, you have to put the numbers in by hand!
+    #for i in np.arange(data.shape[-1]):
+    write_data = data
+    if len(write_data.shape) == 2:
+        write_data = data.copy()[:,:,None]
+
+    driver = gdal.GetDriverByName('GTiff')
+    outDataset = driver.Create(output_filename, 
+                               write_data.shape[1], write_data.shape[0], write_data.shape[2],
+                               gdal.GDT_Float32, options = ['COMPRESS=LZW'])
+    
+
+    for i in range(write_data.shape[-1]):
+        outDataset.GetRasterBand(i+1).WriteArray(write_data[:,:,i])
+        outDataset.GetRasterBand(i+1).SetNoDataValue(-9999)
+    #outDataset.GetRasterBand(1).WriteArray(rgb_data[:,:,0])
+    #outDataset.GetRasterBand(1).SetNoDataValue(-9999)
+    #outDataset.GetRasterBand(2).WriteArray(rgb_data[:,:,1])
+    #outDataset.GetRasterBand(2).SetNoDataValue(-9999)
+    #outDataset.GetRasterBand(3).WriteArray(rgb_data[:,:,2])
+    #outDataset.GetRasterBand(3).SetNoDataValue(-9999)
+    outDataset.SetProjection(meta.projection)
+    outDataset.SetGeoTransform(meta.geotransform)
+    outDataset.FlushCache() ##saves to disk!!
+    outDataset = None
     
 def download_an_AV3_granule(rdn_granule, ghg_granule, storage_location, overwrite = False):
     name = ghg_granule['meta']['native-id']

--- a/spectral_util/earthaccess_helpers.py
+++ b/spectral_util/earthaccess_helpers.py
@@ -107,15 +107,6 @@ def join_AV3_scenes_as_VRT_pixel_time_only(fid, storage_location, output_locatio
 
         # Save the orthoed times to tif so we can make a vrt below
         write_geotiff(d_obs_ort, m_obs, out_tif)
-        #driver = gdal.GetDriverByName('GTiff')
-        #outDataset = driver.Create(out_tif, d_obs_ort.shape[1], d_obs_ort.shape[0], 1,
-        #                           gdal.GDT_Float32, options = ['PROFILE=GeoTIFF'])
-        #outDataset.GetRasterBand(1).WriteArray(d_obs_ort[:,:])
-        #outDataset.GetRasterBand(1).SetNoDataValue(-9999)
-        #outDataset.SetProjection(m_obs.projection)
-        #outDataset.SetGeoTransform(m_obs.geotransform)
-        #outDataset.FlushCache() # saves to disk!!
-        #outDataset = None
 
         j['OBS_ORT_times_only'] = out_tif
         json.dump(j, open(os.path.join(folder, 'data_files.json'),'w'), indent = 4)
@@ -181,27 +172,9 @@ def join_AV3_scenes_as_VRT(fid, granule_storage_location, output_location,
             m_obs, _ = spec_io.load_data(obs_filename, load_glt = True, lazy = False)
             rgb_data = spec_io.ortho_data(d_rgb, m_obs.glt)
 
-            # Make orthoed tif
+            # Make orthoed tif so we can create a vrt below
             rdn_ort_tif_filename = '.'.join(rdn_filename.strip().split('.')[:-1]) + '_ORT.tif'
             write_geotiff(rgb_data, m_obs, rdn_ort_tif_filename)
-            #driver = gdal.GetDriverByName('GTiff')
-            #outDataset = driver.Create(rdn_ort_tif_filename, 
-            #                           rgb_data.shape[1], rgb_data.shape[0], rgb_data.shape[2],
-            #                           gdal.GDT_Float32, options = ['COMPRESS=LZW'])
-            ## This commented out part doesn't work, you have to put the numbers in by hand!
-            ##for i in np.arange(rgb_data.shape[-1]):
-            ##    outDataset.GetRasterBand(i+1).WriteArray(rgb_data[:,:,i])
-            ##    outDataset.GetRasterBand(i+1).SetNoDataValue(-9999)
-            #outDataset.GetRasterBand(1).WriteArray(rgb_data[:,:,0])
-            #outDataset.GetRasterBand(1).SetNoDataValue(-9999)
-            #outDataset.GetRasterBand(2).WriteArray(rgb_data[:,:,1])
-            #outDataset.GetRasterBand(2).SetNoDataValue(-9999)
-            #outDataset.GetRasterBand(3).WriteArray(rgb_data[:,:,2])
-            #outDataset.GetRasterBand(3).SetNoDataValue(-9999)
-            #outDataset.SetProjection(m_obs.projection)
-            #outDataset.SetGeoTransform(m_obs.geotransform)
-            #outDataset.FlushCache() ##saves to disk!!
-            #outDataset = None
 
             j['RDN_QL_ORT'] = rdn_ort_tif_filename
             json.dump(j, open(os.path.join(folder, 'data_files.json'),'w'), indent = 4)
@@ -215,8 +188,6 @@ def join_AV3_scenes_as_VRT(fid, granule_storage_location, output_location,
     return fid_with_scene_numbers
 
 def write_geotiff(data, meta, output_filename):
-    # This commented out part doesn't work, you have to put the numbers in by hand!
-    #for i in np.arange(data.shape[-1]):
     write_data = data
     if len(write_data.shape) == 2:
         write_data = data.copy()[:,:,None]
@@ -225,17 +196,11 @@ def write_geotiff(data, meta, output_filename):
     outDataset = driver.Create(output_filename, 
                                write_data.shape[1], write_data.shape[0], write_data.shape[2],
                                gdal.GDT_Float32, options = ['COMPRESS=LZW'])
-    
 
     for i in range(write_data.shape[-1]):
         outDataset.GetRasterBand(i+1).WriteArray(write_data[:,:,i])
         outDataset.GetRasterBand(i+1).SetNoDataValue(-9999)
-    #outDataset.GetRasterBand(1).WriteArray(rgb_data[:,:,0])
-    #outDataset.GetRasterBand(1).SetNoDataValue(-9999)
-    #outDataset.GetRasterBand(2).WriteArray(rgb_data[:,:,1])
-    #outDataset.GetRasterBand(2).SetNoDataValue(-9999)
-    #outDataset.GetRasterBand(3).WriteArray(rgb_data[:,:,2])
-    #outDataset.GetRasterBand(3).SetNoDataValue(-9999)
+
     outDataset.SetProjection(meta.projection)
     outDataset.SetGeoTransform(meta.geotransform)
     outDataset.FlushCache() ##saves to disk!!

--- a/spectral_util/earthaccess_helpers.py
+++ b/spectral_util/earthaccess_helpers.py
@@ -25,7 +25,7 @@ def find_download_and_combine(output_folder,
                               search_only = False):
     '''Find, download, and combine into VRTs all matching granules and store in OUTPUT_FOLDER
 
-    Rceommended usage: start with --search_only to review FIDs before downloading
+    Recommended usage: start with --search_only to review FIDs before downloading
     
     Search a DAAC using Earthaccess to find granules matching temporal and bounding_box. Download all the L1B and L2B products for
     each granule (except the full radiance as it takes too long and we don't need it generally for GHG analysis). Then, for each line,

--- a/spectral_util/earthaccess_helpers.py
+++ b/spectral_util/earthaccess_helpers.py
@@ -1,0 +1,280 @@
+import os
+import json
+import glob
+from osgeo import gdal
+import pdb
+import click
+
+import earthaccess
+import spec_io
+
+@click.command()
+@click.argument('output_folder', type=click.Path(dir_okay=True, file_okay=False), required=True)
+@click.option('--temporal', type=(click.DateTime(), click.DateTime()), help='Start and end time: %Y-%m-%dT%H:%M:%S %Y-%m-%dT%H:%M:%S')
+@click.option('--count', type=int, default=2000, help='Max number of granules to search earthaccess for')
+@click.option('--bounding_box', type=(float, float, float, float), help='lower_left_lon lower_left_lat upper_right_lon upper_right_lat')
+@click.option('--overwrite', is_flag=True, default=False, help='Set to true to overwrite granules (download them again)')
+@click.option('--symlinks_folder', type=click.Path(exists=True, dir_okay=True, file_okay=False), help = 'Location to put symlinks')
+@click.option('--search_only', is_flag=True, default=False, help='Location to put symlinks')
+def find_download_and_combine(output_folder, 
+                              temporal = None, 
+                              count = 200000,
+                              bounding_box = None,
+                              overwrite = False,
+                              symlinks_folder = None,
+                              search_only = False):
+    '''Find, download, and combine into VRTs all matching granules and store in OUTPUT_FOLDER
+
+    Rceommended usage: start with --seach_only to review FIDs before downloading
+    
+    Search a DAAC using Earthaccess to find granules matching temporal and bounding_box. Download all the L1B and L2B products for
+    each granule (except the full radiance as it takes too long and we don't need it generally for GHG analysis). Then, for each line,
+    combine the granules into a single vrt file so they can be easily handled.
+
+    The file structure is as follows:
+    output_folder/granules/*: all files for each granule are stored here
+    output_folder/AV3*: the vrts are stored here
+
+    For example:
+    output_folder/granules/AV320241004t184138_013_L2B_GHG_1 # Note that the folder name says L2B but its all L1B too (expect rdn)
+    output_folder/granules/AV320241004t184138_014_L2B_GHG_1
+    output_folder/AV320241004t184138_013_014 # Contains the vrts for the two scenes in the granules folder
+
+    If symlinks_folder is provided, then symlinks to each of the vrt folders are created in this folder. The purpose is to have a single
+    repository with links to all the data in it in case you don't remember where you put a case.
+
+    Example call:
+
+    python earthaccess_helpers.py /store/jfahlen/test/av3_October_2024 --temporal 2024-10-04T16:00:00 2024-10-04T17:00:00 --bounding_box -103.74460188 32.22680624 -103.74481188 32.22700624 --search_only
+    '''
+    r_ghg = earthaccess.search_data(short_name = 'AV3_L2B_GHG_2358',
+                                    temporal = temporal, count = count, bounding_box = bounding_box)
+    r_rdn = earthaccess.search_data(short_name = 'AV3_L1B_RDN_2356',
+                                    temporal = temporal, count = count, bounding_box = bounding_box)
+
+    earthaccess_fids = [g['meta']['native-id'] for g in r_ghg] # Ex: AV320241008t193024_003_L2B_GHG_1
+    
+    # Print names
+    if search_only:
+        print(f'Found {len(r_ghg)} GHG and {len(r_rdn)} RDN files.')
+        for earthaccess_fid in earthaccess_fids:
+            print(earthaccess_fid)
+        return
+
+    if os.path.exists(output_folder):
+        if overwrite:
+            raise ValueError(f'The output_folder {output_folder} already exists.')
+    else:
+        os.mkdir(output_folder)
+    if not os.path.exists(output_folder + '/granules'):
+        os.mkdir(output_folder + '/granules')
+
+    for i, (efid, rd, gh) in enumerate(zip(earthaccess_fids, r_rdn, r_ghg)):
+        print(f'Downloading {efid}, #{i+1} of {len(earthaccess_fids)}')
+        download_an_AV3_granule(rd, gh, output_folder + '/granules/', overwrite = False)
+    
+    # Get all FIDs, combining all scene IDs into a single FID
+    fids = sorted(list(set([x.split('_')[0] for x in earthaccess_fids]))) # Ex: AV320241008t193024
+
+    # Make vrt files that combine each scene in a pass into one vrt file
+    fids_with_scene_numbers = [] # Ex: AV320231008t145024_000_001
+    for fid in fids:
+        fid_with_scene_numbers = join_AV3_scenes_as_VRT(fid, output_folder + '/granules/', output_folder + '/')
+        fids_with_scene_numbers.append(fid_with_scene_numbers)
+        join_AV3_scenes_as_VRT_pixel_time_only(fid, output_folder + '/granules/', output_folder + '/')
+    
+    # Make symlinks to the granules folder in the symlinks_folder
+    if symlinks_folder is not None:
+        folders = glob.glob(output_folder + '/granules/*')
+        for folder in folders:
+            dst = f'{symlinks_folder}/{folder.split("/")[-1]}'
+            os.symlink(folder, dst)
+
+def join_AV3_scenes_as_VRT_pixel_time_only(fid, storage_location, output_location):
+    folders = glob.glob(storage_location + f'/{fid}_*')
+    if len(folders) == 0:
+        raise ValueError(f'There are no folders matching ' + storage_location + f'/fid_*')
+    files = []
+    for folder in folders:
+        j = json.load(open(folder + '/data_files.json','r'))
+        obs_filename = j[f'OBS']
+        out_tif = folder + '/' + obs_filename.split('/')[-1].split('.')[0] + '_times_only.tif'
+
+        m_obs, d_obs = spec_io.load_data(obs_filename, load_glt = True, lazy = False)
+        d_obs_ort = spec_io.ortho_data(d_obs[:,:,0], m_obs.glt)
+
+        # Save the orthoed times to tif so we can make a vrt below
+        driver = gdal.GetDriverByName('GTiff')
+        outDataset = driver.Create(out_tif, d_obs_ort.shape[1], d_obs_ort.shape[0], 1,
+                                   gdal.GDT_Float32, options = ['PROFILE=GeoTIFF'])
+        outDataset.GetRasterBand(1).WriteArray(d_obs_ort[:,:,0])
+        outDataset.GetRasterBand(1).SetNoDataValue(-9999)
+        outDataset.SetProjection(m_obs.projection)
+        outDataset.SetGeoTransform(m_obs.geotransform)
+        outDataset.FlushCache() # saves to disk!!
+        outDataset = None
+
+        j['OBS_ORT_times_only'] = out_tif
+        json.dump(j, open(folder + '/data_files.json','w'), indent = 4)
+
+        files.append(out_tif)
+
+    # Create folder and vrt name like: AV320231008t145024_000_001 
+    scene_numbers = [x.strip().split('/')[-1].split('_')[1] for x in files]
+    scene_numbers = sorted(scene_numbers)
+    output_folder = f'{output_location}/{fid}_{scene_numbers[0]}_{scene_numbers[-1]}/'
+    if not os.path.exists(output_folder):
+        os.mkdir(output_folder)
+
+    vrt_filename = f'{output_folder}/{fid}_{scene_numbers[0]}_{scene_numbers[-1]}_obs_times.vrt'
+    my_vrt = gdal.BuildVRT(vrt_filename, files)
+    my_vrt = None
+
+def join_AV3_scenes_as_VRT(fid, granule_storage_location, output_location, 
+                           tags_to_join = ['CH4_UNC_ORT', 'CH4_SNS_ORT', 'CH4_ORT', \
+                                           'CO2_UNC_ORT', 'CO2_SNS_ORT', 'CO2_ORT'], 
+                           rgb_channel_idx = [0,1,2]):
+    '''Combine all the granule files that match {tags_to_join} with {fid} in {granule_storage_location} into 
+    vrt files in output_location.
+
+    Note that the RDN_QL file is done by default, but it needs to be orthorectified
+
+    For reference, good channel indices for rdn rgb are correspond to 641, 552, 462 nm in AV3, or
+    rgb_channel_idx = [34,22,10]
+    '''
+    folders = glob.glob(granule_storage_location + f'/{fid}_*')
+    if len(folders) == 0:
+        raise ValueError(f'There are no folders matching ' + granule_storage_location + f'/fid_*')
+    
+    for tag in tags_to_join:
+        files = []
+        for folder in folders:
+            fs = json.load(open(folder + '/data_files.json','r'))[f'{tag}']
+            files.append(fs)
+
+        scene_numbers = [x.strip().split('/')[-1].split('_')[1] for x in files]
+        scene_numbers = sorted(scene_numbers)
+
+        output_folder = f'{output_location}/{fid}_{scene_numbers[0]}_{scene_numbers[-1]}/'
+        if not os.path.exists(output_folder):
+            os.mkdir(output_folder)
+
+        # Make output name be the fid plume the first and last scene included in the vrt plus the tag
+        fid_with_scene_numbers = f'{fid}_{scene_numbers[0]}_{scene_numbers[-1]}'
+        vrt_filename = f'{output_folder}/{fid_with_scene_numbers}_{tag.split(".")[0]}.vrt'
+        my_vrt = gdal.BuildVRT(vrt_filename, files)
+        my_vrt = None
+
+    # Now convert RDN_QL from unorthoed netCDF4 to orthoed geotiff, then make VRT
+    if rgb_channel_idx is not None:
+        rdn_ort_tif_filenames = []
+        for folder in folders:
+
+            j = json.load(open(folder + '/data_files.json','r'))
+            rdn_filename = j['RDN_QL']
+            obs_filename = j['OBS']
+
+            _, d_rgb = spec_io.load_data(rdn_filename, load_glt = True, lazy = False)
+            m_obs, _ = spec_io.load_data(obs_filename, load_glt = True, lazy = False)
+            rgb_data = spec_io.ortho_data(d_rgb, m_obs.glt)
+
+            # Make orthoed tif
+            rdn_ort_tif_filename = '.'.join(rdn_filename.strip().split('.')[:-1]) + '_ORT.tif'
+            driver = gdal.GetDriverByName('GTiff')
+            outDataset = driver.Create(rdn_ort_tif_filename, 
+                                       rgb_data.shape[1], rgb_data.shape[0], rgb_data.shape[2],
+                                       gdal.GDT_Float32, options = ['COMPRESS=LZW'])
+            # This commented out part doesn't work, you have to put the numbers in by hand!
+            #for i in np.arange(rgb_data.shape[-1]):
+            #    outDataset.GetRasterBand(i+1).WriteArray(rgb_data[:,:,i])
+            #    outDataset.GetRasterBand(i+1).SetNoDataValue(-9999)
+            outDataset.GetRasterBand(1).WriteArray(rgb_data[:,:,0])
+            outDataset.GetRasterBand(1).SetNoDataValue(-9999)
+            outDataset.GetRasterBand(2).WriteArray(rgb_data[:,:,1])
+            outDataset.GetRasterBand(2).SetNoDataValue(-9999)
+            outDataset.GetRasterBand(3).WriteArray(rgb_data[:,:,2])
+            outDataset.GetRasterBand(3).SetNoDataValue(-9999)
+            outDataset.SetProjection(m_obs.projection)
+            outDataset.SetGeoTransform(m_obs.geotransform)
+            outDataset.FlushCache() ##saves to disk!!
+            outDataset = None
+
+            j['RDN_QL_ORT'] = rdn_ort_tif_filename
+            json.dump(j, open(folder + '/data_files.json','w'), indent = 4)
+
+            rdn_ort_tif_filenames.append(rdn_ort_tif_filename)
+        
+        vrt_filename = f'{output_folder}/{fid}_{scene_numbers[0]}_{scene_numbers[-1]}_RDN_ORT.vrt'
+        my_vrt = gdal.BuildVRT(vrt_filename, rdn_ort_tif_filenames)
+        my_vrt = None
+    
+    return fid_with_scene_numbers
+    
+def download_an_AV3_granule(rdn_granule, ghg_granule, storage_location, overwrite = False):
+    name = ghg_granule['meta']['native-id']
+    output_folder = storage_location + '/' + name
+    download = False
+    if not os.path.exists(output_folder):
+        download = True
+        os.mkdir(output_folder)
+    if overwrite:
+        download = True
+    
+    if download:
+        earthaccess.login(persist=True)
+        rdn_files_without_full_RDN = [x for x in rdn_granule.data_links() if 'RDN.nc' not in x]
+        download_from_urls(rdn_files_without_full_RDN, output_folder)
+        download_from_urls(ghg_granule.data_links(), output_folder)
+
+        tags = ['OBS', 'RDN_QL', 'BANDMASK', \
+                'CH4_SNS_ORT', 'CH4_UNC_ORT', 'CH4_ORT_QL', 'CH4_ORT', \
+                'CO2_SNS_ORT', 'CO2_UNC_ORT', 'CO2_ORT_QL', 'CO2_ORT']
+        make_files_list_from_urls_or_glob(rdn_files_without_full_RDN + ghg_granule.data_links(), tags, output_folder)
+
+    return
+
+def download_from_urls(urls, outpath):
+    # Get requests https Session using Earthdata Login Info
+    fs = earthaccess.get_requests_https_session()
+    # Retrieve granule asset ID from URL (to maintain existing naming convention)
+    for url in urls:
+        granule_asset_id = url.split('/')[-1]
+        # Define Local Filepath
+        fp = f'{outpath}/{granule_asset_id}'
+        # Download the Granule Asset if it doesn't exist
+        if not os.path.isfile(fp):
+            with fs.get(url,stream=True) as src:
+                with open(fp,'wb') as dst:
+                    for chunk in src.iter_content(chunk_size=64*1024*1024):
+                        dst.write(chunk)
+
+def make_files_list_from_urls_or_glob(urls, tags, outpath):
+    '''Using a list of URLs from granule.data_links() or the file paths from glob.glob(granules_folder), create and
+    store a json file containing the full path to the granule component files downloaded with download_from_urls. This
+    is helpful since the downloaded files have an unpredictable (or at least hard to find) hash in them.
+    
+    Parameters:
+        urls : list of strings
+            List of URLs or full paths to the granules folder
+        tags : list of strings
+            The file name tags to include in the json file, ex: 'OBS', 'CH4_SNS_ORT', etc.
+        output : string
+            The path to the granules location where the output json will go
+    '''
+    # URL example: https://data.ornldaac.earthdata.nasa.gov/protected/aviris/AV3_L1B_RDN/data/AV320241002t160425_014_L1B_ORT_55901fd4_OBS.nc
+    urls_cut = [url.split('/')[-1] for url in urls] # Ex: AV320241002t160425_014_L1B_ORT_55901fd4_OBS 
+    urls_cut_noext = [x.split('.')[0] for x in urls_cut]
+
+    files_list = {}
+    for tag in tags:
+        try:
+            ind = [i for i, x in enumerate(urls_cut_noext) if x.endswith(tag)][0]
+        except:
+            pdb.set_trace()
+        files_list[tag] = os.path.join(outpath, f'{urls_cut[ind]}')
+    
+    json.dump(files_list, open(outpath + '/data_files.json', 'w'), indent = 4)
+    return
+
+if __name__ == '__main__':
+    find_download_and_combine()


### PR DESCRIPTION
@pgbrodrick: earthaccess_helpers.py adds functionality to find, download, and combine into VRTs a collection of AV3 lines. This is a routine operation for me so I thought it might be helpful for others.

Example usage:
python earthaccess_helpers.py /store/jfahlen/test/av3_October_2024 --temporal 2024-10-04T16:00:00 2024-10-04T17:00:00 --bounding_box -103.74460188 32.22680624 -103.74481188 32.22700624

This will find all matching GHG and RDN granules for AV3. For each pair of granules, all associated files will be downloaded and a simple file manifest will be produced. For each line (with possibly many granules), a second folder will be created with VRT files of all the downloaded scenes in the granule.

**NOTE**: this requires my other PRs: #9, #10, and #11 

This assumes a user has an environment with earthaccess installed.

This focuses on GHG products, so not all files are downloaded, included the full RDN.

At this point, it does not do EMIT, but that should be an easy upgrade.