### PR TITLE
Branch on filename not fullpath

### DIFF
--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -300,15 +300,16 @@ def open_netcdf(input_file, lazy=True, load_glt=False, load_loc=False):
             - Metadata: An object containing the appropriate metadata
             - numpy.ndarray or netCDF4.Variable: The data, either as a lazy-loaded variable or a fully loaded numpy array.
     """
-    if 'EMIT' in input_file and 'RAD' in input_file:
+    input_filename = os.path.basename(input_file)
+    if 'EMIT' in input_filename and 'RAD' in input_filename:
         return open_emit_rdn(input_file, lazy=lazy, load_glt=load_glt)
-    elif 'AV3' in input_file and 'RFL' in input_file:
+    elif 'AV3' in input_filename and 'RFL' in input_filename:
         return open_airborne_rfl(input_file, lazy=lazy)
-    elif 'AV3' in input_file and 'RDN' in input_file:
+    elif 'AV3' in input_filename and 'RDN' in input_filename:
         return open_airborne_rdn(input_file, lazy=lazy)
-    elif ('av3' in input_file.lower() or 'ang' in input_file.lower()) and 'OBS' in input_file:
+    elif ('av3' in input_filename.lower() or 'ang' in input_filename.lower()) and 'OBS' in input_filename:
         return open_airborne_obs(input_file, lazy=lazy, load_glt=load_glt, load_loc=load_loc)
-    elif 'ang' in input_file.lower()  and 'rfl' in input_file.lower():
+    elif 'ang' in input_filename.lower()  and 'rfl' in input_filename.lower():
         return open_airborne_rfl(input_file, lazy=lazy)
     else:
         raise ValueError(f'Unknown file type for {input_file}')

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -111,11 +111,13 @@ def load_data(input_file, lazy=True, load_glt=False, load_loc=False):
     """
     if not os.path.exists(input_file):
         raise FileNotFoundError(f'{input_file} not found.')
-    if input_file.endswith(('.hdr', '.dat', '.img')) or '.' not in os.path.basename(input_file):
+
+    input_filename = os.path.basename(input_file)
+    if input_filename.endswith(('.hdr', '.dat', '.img')) or '.' not in input_filename:
         return open_envi(input_file, lazy=lazy)
-    elif input_file.endswith('.nc'):
+    elif input_filename.endswith('.nc'):
         return open_netcdf(input_file, lazy=lazy, load_glt=load_glt, load_loc=load_loc)
-    elif input_file.endswith('.tif') or input_file.endswith('.vrt'):
+    elif input_filename.endswith('.tif') or input_filename.endswith('.vrt'):
         return open_tif(input_file, lazy=lazy)
     else:
         raise ValueError(f'Unknown file type for {input_file}')


### PR DESCRIPTION
Fixes a problem in which spec_io.load_data will fail because the branching code for deciding what kind of file it is uses the full path instead of just the file name. As a result, an OBS file with RDN in the path will incorrectly use open_airborne_rdn instead of open_airborne_obs.

For example, it will fail on this file since RDN is in the folder name:

```
In [396]: m, d = spec_io.load_data('/store/jfahlen/av3_casa_grande_Nov2024_withRDN/granules/AV320241104t180240_001_L2
     ...: B_GHG_1/AV320241104t180240_001_L1B_ORT_55901fd4_OBS.nc', load_glt=True)
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[396], line 1
----> 1 m, d = spec_io.load_data('/store/jfahlen/av3_casa_grande_Nov2024_withRDN/granules/AV320241104t180240_001_L2B_GHG_1/AV320241104t180240_001_L1B_ORT_55901fd4_OBS.nc', load_glt=True)

File ~/src/SpectralUtil/spectral_util/spec_io.py:119, in load_data(input_file, lazy, load_glt, load_loc)
    117     return open_envi(input_file, lazy=lazy)
    118 elif input_filename.endswith('.nc'):
--> 119     return open_netcdf(input_file, lazy=lazy, load_glt=load_glt, load_loc=load_loc)
    120 elif input_filename.endswith('.tif') or input_filename.endswith('.vrt'):
    121     return open_tif(input_file, lazy=lazy)

File ~/src/SpectralUtil/spectral_util/spec_io.py:308, in open_netcdf(input_file, lazy, load_glt, load_loc)
    306     return open_airborne_rfl(input_file, lazy=lazy)
    307 elif 'AV3' in input_file and 'RDN' in input_file:
--> 308     return open_airborne_rdn(input_file, lazy=lazy)
    309 elif ('av3' in input_file.lower() or 'ang' in input_file.lower()) and 'OBS' in input_file:
    310     return open_airborne_obs(input_file, lazy=lazy, load_glt=load_glt, load_loc=load_loc)

File ~/src/SpectralUtil/spectral_util/spec_io.py:397, in open_airborne_rdn(input_file, lazy)
    384 """
    385 Opens an Airborne radiance NetCDF file and extracts the spectral metadata and radiance data.
    386 
   (...)
    394         - numpy.ndarray or netCDF4.Variable: The radiance data, either as a lazy-loaded variable or a fully loaded numpy array.
    395 """
    396 ds = nc.Dataset(input_file)
--> 397 wl = ds['radiance']['wavelength'][:]
    398 fwhm = ds['radiance']['fwhm'][:]
    399 proj = ds.variables['transverse_mercator'].spatial_ref

File src/netCDF4/_netCDF4.pyx:2570, in netCDF4._netCDF4.Dataset.__getitem__()

IndexError: radiance not found in /

```