### PR TITLE
Add write_envi_file

### DIFF
--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -479,6 +479,16 @@ def get_extent_from_obs(input_file, get_resolution=False):
     else:
         return np.min(lon), np.max(lat), np.max(lon), np.min(lat)
 
+def write_envi_file(dat, meta, output_filename):
+    """
+    Write an ENVI file
+    Args:
+        dat: data to write: nx, ny, nbands
+        meta (SpectralMetadata): The spectral metadata contianing wavelengths and FWHM
+        output_filename: Output file name (no extension)
+    """
+    create_envi_file(output_filename, dat.shape, meta, dtype = dat.dtype)
+    write_bil_chunk(dat.transpose([0,2,1]), output_filename, 0, (dat.shape[0], dat.shape[2], dat.shape[1]))
 
 def write_bil_chunk(dat, outfile, line, shape, dtype = 'float32'):
     """

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -239,7 +239,8 @@ def open_envi(input_file, lazy=True):
         nodata_value = -9999 # set default
 
     if 'coordinate system string' in imeta:
-        proj = imeta['coordinate system string']
+        css = imeta['coordinate system string']
+        proj = css if type(css) == str else ','.join(css)
     else:
         proj = None
     if 'map info' in imeta:

--- a/spectral_util/spec_io.py
+++ b/spectral_util/spec_io.py
@@ -480,14 +480,18 @@ def get_extent_from_obs(input_file, get_resolution=False):
     else:
         return np.min(lon), np.max(lat), np.max(lon), np.min(lat)
 
-def write_envi_file(dat, meta, output_filename):
+def write_envi_file(dat, meta, output_filename, interleave = 'BIL'):
     """
     Write an ENVI file
     Args:
         dat: data to write: nx, ny, nbands
         meta (SpectralMetadata): The spectral metadata contianing wavelengths and FWHM
         output_filename: Output file name (no extension)
+        interleave: string to indicate interleave method
     """
+    if interleave.lower() != 'bil':
+        raise NotImplementedError(f'Print interleave mode {interleave} not yet supported.')
+
     create_envi_file(output_filename, dat.shape, meta, dtype = dat.dtype)
     write_bil_chunk(dat.transpose([0,2,1]), output_filename, 0, (dat.shape[0], dat.shape[2], dat.shape[1]))
 


### PR DESCRIPTION
Adds a wrapper to write an ENVI file so you don't have to figure out the transposes every time.

Please check the comments and the transpose. It might not be clear. I tested this with the below, but it might not work right for unorthoed data.

```
m, d = spec_io.load_data('/store/jfahlen/av3_casa_grande_Nov2024_with_rdn/granules/AV320241104t180240_001_L2B_GHG_1/AV320241104t180240_001_L1B_ORT_55901fd4_OBS.nc', load_glt=True)
do = spec_io.ortho_data(d, m.glt)
spec_io.write_envi(do, m, '/store/jfahlen/test/test')
```